### PR TITLE
Update BlockPlayerListener.java

### DIFF
--- a/LockettePro/src/me/crafter/mc/lockettepro/BlockPlayerListener.java
+++ b/LockettePro/src/me/crafter/mc/lockettepro/BlockPlayerListener.java
@@ -243,6 +243,9 @@ public class BlockPlayerListener implements Listener {
     public void onAttemptInteractLockedBlocks(PlayerInteractEvent event){
         Action action = event.getAction();
         Block block = event.getClickedBlock();
+        if (block == null) {
+            return;
+        }
         if (LockettePro.needCheckHand() && LocketteProAPI.isChest(block)){
             if (event.getHand() != EquipmentSlot.HAND){
                 if (action == Action.RIGHT_CLICK_BLOCK){


### PR DESCRIPTION
Fix Could not pass event PlayerInteractEvent to LockettePro v2.10.5 NPE because block can be null.