### PR TITLE
Prevent all NullPointerExceptions in BlockPlayerListener

### DIFF
--- a/LockettePro/src/me/crafter/mc/lockettepro/BlockPlayerListener.java
+++ b/LockettePro/src/me/crafter/mc/lockettepro/BlockPlayerListener.java
@@ -49,6 +49,7 @@ public class BlockPlayerListener implements Listener {
             BlockFace blockface = event.getBlockFace();
             if (blockface == BlockFace.NORTH || blockface == BlockFace.WEST || blockface == BlockFace.EAST || blockface == BlockFace.SOUTH){
                 Block block = event.getClickedBlock();
+                if (block == null) return;
                 // Check permission with external plugin
                 if (Dependency.isProtectedFrom(block, player)) return; // blockwise
                 if (Dependency.isProtectedFrom(block.getRelative(event.getBlockFace()), player)) return; // signwise
@@ -110,6 +111,7 @@ public class BlockPlayerListener implements Listener {
     public void onManualLock(SignChangeEvent event){
         if (!Tag.WALL_SIGNS.isTagged(event.getBlock().getType())) return;
         String topline = event.getLine(0);
+        if (topline == null) topline = "";
         Player player = event.getPlayer();
         /*  Issue #46 - Old version of Minecraft trim signs in unexpected way.
          *  This is caused by Minecraft was doing: (unconfirmed but seemingly)
@@ -179,8 +181,9 @@ public class BlockPlayerListener implements Listener {
     // Player select sign
     @EventHandler(priority = EventPriority.LOW)
     public void playerSelectSign(PlayerInteractEvent event){
-        if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.hasBlock() && Tag.WALL_SIGNS.isTagged(event.getClickedBlock().getType())) {
-            Block block = event.getClickedBlock();
+        Block block = event.getClickedBlock();
+        if (block == null) return;
+        if (event.getAction() == Action.RIGHT_CLICK_BLOCK && event.hasBlock() && Tag.WALL_SIGNS.isTagged(block.getType())) {
             Player player = event.getPlayer();
             if (!player.hasPermission("lockettepro.edit")) return;
             if (LocketteProAPI.isOwnerOfSign(block, player) || (LocketteProAPI.isLockSignOrAdditionalSign(block) && player.hasPermission("lockettepro.admin.edit"))){

--- a/LockettePro/src/me/crafter/mc/lockettepro/LocketteProAPI.java
+++ b/LockettePro/src/me/crafter/mc/lockettepro/LocketteProAPI.java
@@ -1,6 +1,8 @@
 package me.crafter.mc.lockettepro;
 
-import org.bukkit.*;
+import org.bukkit.Effect;
+import org.bukkit.Material;
+import org.bukkit.Tag;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.Container;
@@ -11,11 +13,13 @@ import org.bukkit.block.data.Waterlogged;
 import org.bukkit.block.data.type.Chest;
 import org.bukkit.entity.Player;
 
+import javax.annotation.Nullable;
+
 public class LocketteProAPI {
 
     public static BlockFace[] newsfaces = {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST};
     public static BlockFace[] allfaces = {BlockFace.NORTH, BlockFace.EAST, BlockFace.SOUTH, BlockFace.WEST, BlockFace.UP, BlockFace.DOWN};
-    
+
     public static boolean isLocked(Block block){
         if (block == null) return false;
         switch (block.getType()){
@@ -36,13 +40,13 @@ public class LocketteProAPI {
                 if (relative0.getType() == doors[0].getType() && relative1.getType() == doors[1].getType()){
                     if (isLockedSingleBlock(relative1.getRelative(BlockFace.UP), doorface.getOppositeFace())) return true;
                     if (isLockedSingleBlock(relative1, doorface.getOppositeFace())) return true;
-                    if (isLockedSingleBlock(relative0, doorface.getOppositeFace())) return true; 
-                    if (isLockedSingleBlock(relative0.getRelative(BlockFace.DOWN), doorface.getOppositeFace())) return true; 
+                    if (isLockedSingleBlock(relative0, doorface.getOppositeFace())) return true;
+                    if (isLockedSingleBlock(relative0.getRelative(BlockFace.DOWN), doorface.getOppositeFace())) return true;
                 }
             }
             if (isLockedSingleBlock(doors[1].getRelative(BlockFace.UP), null)) return true;
             if (isLockedSingleBlock(doors[1], null)) return true;
-            if (isLockedSingleBlock(doors[0], null)) return true; 
+            if (isLockedSingleBlock(doors[0], null)) return true;
             if (isLockedSingleBlock(doors[0].getRelative(BlockFace.DOWN), null)) return true;
             break;
         case LECTERN:
@@ -59,12 +63,12 @@ public class LocketteProAPI {
             // Don't break here
         // Everything else (First block of container check goes here)
         default:
-            if (isLockedSingleBlock(block, null)) return true; 
+            if (isLockedSingleBlock(block, null)) return true;
             break;
         }
         return false;
     }
-    
+
     public static String getOwner(Block block){
         switch (block.getType()){
         // Double Doors
@@ -128,7 +132,7 @@ public class LocketteProAPI {
         }
         return null;
     }
-    
+
     public static boolean isOwner(Block block, Player player){
         switch (block.getType()){
         // Double Doors
@@ -148,13 +152,13 @@ public class LocketteProAPI {
                 if (relative0.getType() == doors[0].getType() && relative1.getType() == doors[1].getType()){
                     if (isOwnerSingleBlock(relative1.getRelative(BlockFace.UP), doorface.getOppositeFace(), player)) return true;
                     if (isOwnerSingleBlock(relative1, doorface.getOppositeFace(), player)) return true;
-                    if (isOwnerSingleBlock(relative0, doorface.getOppositeFace(), player)) return true; 
-                    if (isOwnerSingleBlock(relative0.getRelative(BlockFace.DOWN), doorface.getOppositeFace(), player)) return true; 
+                    if (isOwnerSingleBlock(relative0, doorface.getOppositeFace(), player)) return true;
+                    if (isOwnerSingleBlock(relative0.getRelative(BlockFace.DOWN), doorface.getOppositeFace(), player)) return true;
                 }
             }
             if (isOwnerSingleBlock(doors[1].getRelative(BlockFace.UP), null, player)) return true;
             if (isOwnerSingleBlock(doors[1], null, player)) return true;
-            if (isOwnerSingleBlock(doors[0], null, player)) return true; 
+            if (isOwnerSingleBlock(doors[0], null, player)) return true;
             if (isOwnerSingleBlock(doors[0].getRelative(BlockFace.DOWN), null, player)) return true;
             break;
         // Chests (Second block only)
@@ -171,7 +175,7 @@ public class LocketteProAPI {
             // Don't break here
         // Everything else (First block of container check goes here)
         default:
-            if (isOwnerSingleBlock(block, null, player)) return true; 
+            if (isOwnerSingleBlock(block, null, player)) return true;
             break;
         }
         return false;
@@ -196,13 +200,13 @@ public class LocketteProAPI {
                 if (relative0.getType() == doors[0].getType() && relative1.getType() == doors[1].getType()){
                     if (isUserSingleBlock(relative1.getRelative(BlockFace.UP), doorface.getOppositeFace(), player)) return true;
                     if (isUserSingleBlock(relative1, doorface.getOppositeFace(), player)) return true;
-                    if (isUserSingleBlock(relative0, doorface.getOppositeFace(), player)) return true; 
-                    if (isUserSingleBlock(relative0.getRelative(BlockFace.DOWN), doorface.getOppositeFace(), player)) return true; 
+                    if (isUserSingleBlock(relative0, doorface.getOppositeFace(), player)) return true;
+                    if (isUserSingleBlock(relative0.getRelative(BlockFace.DOWN), doorface.getOppositeFace(), player)) return true;
                 }
             }
             if (isUserSingleBlock(doors[1].getRelative(BlockFace.UP), null, player)) return true;
             if (isUserSingleBlock(doors[1], null, player)) return true;
-            if (isUserSingleBlock(doors[0], null, player)) return true; 
+            if (isUserSingleBlock(doors[0], null, player)) return true;
             if (isUserSingleBlock(doors[0].getRelative(BlockFace.DOWN), null, player)) return true;
             break;
         // Lecterns
@@ -220,16 +224,16 @@ public class LocketteProAPI {
             // Don't break here
         // Everything else (First block of container check goes here)
         default:
-            if (isUserSingleBlock(block, null, player)) return true; 
+            if (isUserSingleBlock(block, null, player)) return true;
             break;
         }
         return false;
     }
-    
+
     public static boolean isProtected(Block block){
         return (isLockSign(block) || isLocked(block) || isUpDownLockedDoor(block));
     }
-    
+
     public static boolean isLockedSingleBlock(Block block, BlockFace exempt){
         for (BlockFace blockface : newsfaces){
             if (blockface == exempt) continue;
@@ -245,7 +249,7 @@ public class LocketteProAPI {
         }
         return false;
     }
-    
+
     public static boolean isOwnerSingleBlock(Block block, BlockFace exempt, Player player){ // Requires isLocked
         for (BlockFace blockface : newsfaces){
             if (blockface == exempt) continue;
@@ -258,7 +262,7 @@ public class LocketteProAPI {
         }
         return false;
     }
-    
+
     public static String getLockOwnerSingleBlock(Block block, BlockFace exempt) {
     	for (BlockFace blockface : newsfaces){
             if (blockface == exempt) continue;
@@ -269,7 +273,7 @@ public class LocketteProAPI {
         }
     	return null;
     }
-    
+
     public static boolean isUserSingleBlock(Block block, BlockFace exempt, Player player){ // Requires isLocked
         for (BlockFace blockface : newsfaces){
             if (blockface == exempt) continue;
@@ -282,7 +286,7 @@ public class LocketteProAPI {
         }
         return false;
     }
-    
+
     public static boolean isOwnerOfSign(Block block, Player player){ // Requires isSign
         Block protectedblock = getAttachedBlock(block);
         // Normal situation, that block is just locked by an adjacent sign
@@ -292,7 +296,7 @@ public class LocketteProAPI {
         // Otherwise...
         return false;
     }
-    
+
     public static boolean isLockable(Block block){
         Material material = block.getType();
         //Bad blocks
@@ -309,9 +313,12 @@ public class LocketteProAPI {
             return false;
         }
     }
-    
 
-    public static boolean isChest(Block block){
+
+    public static boolean isChest(@Nullable Block block){
+        if (block == null) {
+            return false;
+        }
         switch (block.getType()){
         case CHEST:
         case TRAPPED_CHEST:
@@ -320,7 +327,7 @@ public class LocketteProAPI {
             return false;
         }
     }
-    
+
     public static boolean isUpDownAlsoLockableBlock(Block block){
         if (Config.isLockable(block.getType())){
             switch (block.getType()){
@@ -340,7 +347,7 @@ public class LocketteProAPI {
         }
         return false;
     }
-    
+
     public static boolean mayInterfere(Block block, Player player){
         if (block.getState() instanceof Container) {
             for (BlockFace blockface : allfaces) {
@@ -405,7 +412,7 @@ public class LocketteProAPI {
         case SPRUCE_SIGN:
         case BIRCH_SIGN:
         case JUNGLE_SIGN:
-        case ACACIA_SIGN: 
+        case ACACIA_SIGN:
         case DARK_OAK_SIGN:
             for (BlockFace blockface : allfaces){
                 Block newblock = block.getRelative(blockface);
@@ -446,19 +453,19 @@ public class LocketteProAPI {
         }
         return false;
     }
-    
+
     public static boolean isSign(Block block){
         return Tag.WALL_SIGNS.isTagged(block.getType());
     }
-    
+
     public static boolean isLockSign(Block block){
         return isSign(block) && isLockString(((Sign)block.getState()).getLine(0));
     }
-    
+
     public static boolean isAdditionalSign(Block block){
         return isSign(block) && isAdditionalString(((Sign)block.getState()).getLine(0));
     }
-    
+
     public static boolean isLockSignOrAdditionalSign(Block block){
         if (isSign(block)){
             String line = ((Sign)block.getState()).getLine(0);
@@ -467,7 +474,7 @@ public class LocketteProAPI {
             return false;
         }
     }
-    
+
     public static boolean isOwnerOnSign(Block block, Player player){ // Requires isLockSign
         String[] lines = ((Sign)block.getState()).getLines();
         if (Utils.isPlayerOnLine(player, lines[1])){
@@ -478,12 +485,12 @@ public class LocketteProAPI {
         }
         return false;
     }
-    
+
     public static String getOwnerOnSign(Block block){ // Requires isLockSign
         String[] lines = ((Sign)block.getState()).getLines();
         return lines[1];
     }
-    
+
     public static boolean isUserOnSign(Block block, Player player){ // Requires (isLockSign or isAdditionalSign)
         String[] lines = ((Sign)block.getState()).getLines();
         // Normal
@@ -504,27 +511,30 @@ public class LocketteProAPI {
         }
         return false;
     }
-    
+
     public static boolean isSignExpired(Block block){
         if (!isSign(block) || !isLockSign(block)) return false;
         return isLineExpired(((Sign)block.getState()).getLine(0));
     }
-    
+
     public static boolean isLineExpired(String line){
         long createdtime = Utils.getCreatedFromLine(line);
         if (createdtime == -1L) return false; // No expire
         long currenttime = (int)(System.currentTimeMillis()/1000);
         return createdtime + Config.getLockExpireDays() * 86400L < currenttime;
     }
-    
-    public static boolean isUpDownLockedDoor(Block block){
+
+    public static boolean isUpDownLockedDoor(@Nullable Block block){
+        if (block == null) {
+            return false;
+        }
         Block blockup = block.getRelative(BlockFace.UP);
         if (blockup != null && isUpDownAlsoLockableBlock(blockup) && isLocked(blockup)) return true;
         Block blockdown = block.getRelative(BlockFace.DOWN);
         if (blockdown != null && isUpDownAlsoLockableBlock(blockdown) && isLocked(blockdown)) return true;
         return false;
     }
-    
+
     public static boolean isOwnerUpDownLockedDoor(Block block, Player player){
         Block blockup = block.getRelative(BlockFace.UP);
         if (blockup != null && isUpDownAlsoLockableBlock(blockup) && isOwner(blockup, player)) return true;
@@ -532,7 +542,7 @@ public class LocketteProAPI {
         if (blockdown != null && isUpDownAlsoLockableBlock(blockdown) && isOwner(blockdown, player)) return true;
         return false;
     }
-    
+
     public static boolean isUserUpDownLockedDoor(Block block, Player player){
         Block blockup = block.getRelative(BlockFace.UP);
         if (blockup != null && isUpDownAlsoLockableBlock(blockup) && isUser(blockup, player)) return true;
@@ -540,17 +550,17 @@ public class LocketteProAPI {
         if (blockdown != null && isUpDownAlsoLockableBlock(blockdown) && isUser(blockdown, player)) return true;
         return false;
     }
-    
+
     public static boolean isLockString(String line){
         if (line.contains("#")) line = line.split("#", 2)[0];
         return Config.isPrivateSignString(line);
     }
-    
+
     public static boolean isAdditionalString(String line){
         if (line.contains("#")) line = line.split("#", 2)[0];
         return Config.isAdditionalSignString(line);
     }
-    
+
     public static boolean isLockStringOrAdditionalString(String line){
         return isLockString(line) || isAdditionalString(line);
     }
@@ -559,7 +569,7 @@ public class LocketteProAPI {
         BlockFace facing = getFacing(sign);
         return sign.getRelative(facing.getOppositeFace());
     }
-    
+
     public static int getTimerOnSigns(Block block){
         for (BlockFace blockface : newsfaces){
             Block relative = block.getRelative(blockface);
@@ -584,7 +594,7 @@ public class LocketteProAPI {
         }
         return 0;
     }
-    
+
     public static int getTimerSingleDoor(Block block){
         Block[] doors = getDoors(block);
         if (doors == null) return 0;
@@ -600,7 +610,7 @@ public class LocketteProAPI {
         if (relativedowntimer > 0) return relativedowntimer;
         return 0;
     }
-    
+
     public static Block[] getDoors(Block block){
         Block[] doors = new Block[2];
         boolean found = false;
@@ -621,12 +631,18 @@ public class LocketteProAPI {
         }
         return doors;
     }
-    
-    public static boolean isDoubleDoorBlock(Block block){
+
+    public static boolean isDoubleDoorBlock(@Nullable Block block){
+        if (block == null) {
+            return false;
+        }
         return Tag.DOORS.isTagged(block.getType());
     }
-    
-    public static boolean isSingleDoorBlock(Block block){
+
+    public static boolean isSingleDoorBlock(@Nullable Block block){
+        if (block == null) {
+            return false;
+        }
         switch (block.getType()){
         case OAK_FENCE_GATE:
         case SPRUCE_FENCE_GATE:
@@ -635,7 +651,7 @@ public class LocketteProAPI {
         case WARPED_FENCE_GATE:
         case ACACIA_FENCE_GATE:
         case JUNGLE_FENCE_GATE:
-        case ACACIA_TRAPDOOR: 
+        case ACACIA_TRAPDOOR:
         case DARK_OAK_TRAPDOOR:
         case CRIMSON_TRAPDOOR:
         case WARPED_TRAPDOOR:
@@ -645,10 +661,10 @@ public class LocketteProAPI {
         case IRON_TRAPDOOR:
             return true;
         default:
-            return false;	
-        }	
+            return false;
+        }
     }
-    
+
     public static Block getBottomDoorBlock(Block block){ // Requires isDoubleDoorBlock || isSingleDoorBlock
         if (isDoubleDoorBlock(block)){
             Block relative = block.getRelative(BlockFace.DOWN);


### PR DESCRIPTION
Fixes: #17

Fixes this `NullPointerException` among others:
```
[23:18:11] [Server thread/ERROR]: Could not pass event PlayerInteractEvent to LockettePro v2.10.5
java.lang.NullPointerException: null
        at me.crafter.mc.lockettepro.LocketteProAPI.isChest(LocketteProAPI.java:315) ~[?:?]
        at me.crafter.mc.lockettepro.BlockPlayerListener.onAttemptInteractLockedBlocks(BlockPlayerListener.java:246) ~[?:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor207.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor.lambda$create$1(EventExecutor.java:69) ~[patched_1.16.2.jar:git-Paper-168]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:80) ~[patched_1.16.2.jar:git-Paper-168]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[patched_1.16.2.jar:git-Paper-168]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:607) ~[patched_1.16.2.jar:git-Paper-168]
        at org.bukkit.craftbukkit.v1_16_R2.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:502) ~[patched_1.16.2.jar:git-Paper-168]
        at org.bukkit.craftbukkit.v1_16_R2.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:469) ~[patched_1.16.2.jar:git-Paper-168]
        at org.bukkit.craftbukkit.v1_16_R2.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:465) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.PlayerConnection.a(PlayerConnection.java:1940) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.PacketPlayInArmAnimation.a(SourceFile:31) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.PacketPlayInArmAnimation.a(SourceFile:9) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.PlayerConnectionUtils.lambda$ensureMainThread$1(PlayerConnectionUtils.java:23) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.TickTask.run(SourceFile:18) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.IAsyncTaskHandler.executeTask(IAsyncTaskHandler.java:136) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.IAsyncTaskHandlerReentrant.executeTask(SourceFile:23) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.IAsyncTaskHandler.executeNext(IAsyncTaskHandler.java:109) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.MinecraftServer.ba(MinecraftServer.java:1135) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.MinecraftServer.executeNext(MinecraftServer.java:1128) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.IAsyncTaskHandler.awaitTasks(IAsyncTaskHandler.java:119) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.MinecraftServer.sleepForTick(MinecraftServer.java:1089) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.MinecraftServer.w(MinecraftServer.java:1003) ~[patched_1.16.2.jar:git-Paper-168]
        at net.minecraft.server.v1_16_R2.MinecraftServer.lambda$a$0(MinecraftServer.java:177) ~[patched_1.16.2.jar:git-Paper-168]
        at java.lang.Thread.run(Thread.java:748) [?:1.8.0_265]
```