### PR TITLE
Locking sign keeps its material type

### DIFF
--- a/LockettePro/src/me/crafter/mc/lockettepro/BlockPlayerListener.java
+++ b/LockettePro/src/me/crafter/mc/lockettepro/BlockPlayerListener.java
@@ -86,14 +86,16 @@ public class BlockPlayerListener implements Listener {
                         Dependency.logPlacement(player, newsign);
                     } else if (!locked && LocketteProAPI.isOwnerUpDownLockedDoor(block, player)){
                         // Not locked, (is locked door nearby), is owner of locked door nearby
+                        Material signType = player.getInventory().getItemInMainHand().getType();
                         Utils.removeASign(player);
                         Utils.sendMessages(player, Config.getLang("additional-sign-added-quick"));
-                        Utils.putSignOn(block, blockface, Config.getDefaultAdditionalString(), "", player.getInventory().getItemInMainHand().getType());
+                        Utils.putSignOn(block, blockface, Config.getDefaultAdditionalString(), "", signType);
                         Dependency.logPlacement(player, block.getRelative(blockface));
                     } else if (LocketteProAPI.isOwner(block, player)) {
                         // Locked, (not locked door nearby), is owner of locked block
+                        Material signType = player.getInventory().getItemInMainHand().getType();
                         Utils.removeASign(player);
-                        Utils.putSignOn(block, blockface, Config.getDefaultAdditionalString(), "", player.getInventory().getItemInMainHand().getType());
+                        Utils.putSignOn(block, blockface, Config.getDefaultAdditionalString(), "", signType);
                         Utils.sendMessages(player, Config.getLang("additional-sign-added-quick"));
                         Dependency.logPlacement(player, block.getRelative(blockface));
                     } else {


### PR DESCRIPTION
The case happens when a player tries to attach an 2nd lock sign on a chest. If the sign is the last one that (s)he's held, it therefore changes to an OAK_WALL_SIGN whatever it was. Because removeASign takes it a way (ie: changes it as AIR) and the next getItemInMainHand() cannot get the signtype anymore.

Confirmed on 1.16.1, PaperMC.

