### PR TITLE
fix fr typo

### DIFF
--- a/LockettePro/src/lang_fr.yml
+++ b/LockettePro/src/lang_fr.yml
@@ -1,7 +1,7 @@
 # German translation by Morgan_vonBrylan
 
 command-usage: "&6[LockettePro] aide du plugin &bLockettePro\n&c1. Pour ajouter un joueur au panneau, faites clic droit dessus, puis entrez /lock <ligne> <texte> pour changer la ligne.\n&c2. Pour recharger la configuration, entrez /lock reload.\nLockettePro par connection_lost"
-you-can-quick-lock-it: '&6[LockettePro] &aClick droit sur un bloc avec un panneau pour le verrouiller.'
+you-can-quick-lock-it: '&6[LockettePro] &aClic droit sur un bloc avec un panneau pour le verrouiller.'
 you-can-manual-lock-it: '&6[LockettePro] &aPlacez un panneau et écrivez [Private] pour le verrouiller.'
 config-reloaded: '&6[LockettePro] &aConfiguration rechargée.'
 no-permission: '&6[LockettePro] &cVous n''avez pas la permission de faire ça.'
@@ -27,7 +27,7 @@ break-own-lock-sign: '&6[LockettePro] &aVous avez cassé votre panneau verrou.'
 cannot-break-this-lock-sign: '&6[LockettePro] &cVous ne pouvez pas casser ce panneau verrou.'
 break-own-additional-sign: '&6[LockettePro] &aVous avez cassé votre panneau supplémentaire.'
 break-redundant-additional-sign: '&6[LockettePro] &aVous avez cassé un panneau supplémentaire redondant.'
-cannot-break-this-additional-sign: '&6[LockettePro] &cVous ne pouvez pas cesser ce panneau supplémentaire.'
+cannot-break-this-additional-sign: '&6[LockettePro] &cVous ne pouvez pas casser ce panneau supplémentaire.'
 block-is-locked: '&6[LockettePro] &cCe bloc est verrouillé.'
 cannot-interfere-with-others: '&6[LockettePro] &cVous ne pouvez pas placer de bloc qui pourrait interférer avec d''autres.'
 sign-error: '&4[ERREUR]'


### PR DESCRIPTION
The header should say "French translation" as well, but I don't know the author so I can't modify that