### PR TITLE
Fixed Iron Doors

### DIFF
--- a/LockettePro/src/me/crafter/mc/lockettepro/BlockPlayerListener.java
+++ b/LockettePro/src/me/crafter/mc/lockettepro/BlockPlayerListener.java
@@ -24,6 +24,7 @@ import org.bukkit.scheduler.BukkitRunnable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class BlockPlayerListener implements Listener {
 
@@ -247,6 +248,7 @@ public class BlockPlayerListener implements Listener {
     @EventHandler(priority = EventPriority.HIGH)
     public void onAttemptInteractLockedBlocks(PlayerInteractEvent event) {
     	if (event.hasBlock() == false) return;
+        if (Objects.equals(event.getHand(), EquipmentSlot.OFF_HAND)) return;
         Action action = event.getAction();
         Block block = event.getClickedBlock();
         if (LockettePro.needCheckHand() && LocketteProAPI.isChest(block)){


### PR DESCRIPTION
Fixed issue with opening iron doors by preventing the event to be cast twice (once for offhand, once for main hand)